### PR TITLE
Update macos.yml added pkgconf

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          # brew install libtiff openssl@3 pkg-config
+          # brew install libtiff openssl@3
           brew install \
             autoconf \
             automake \
@@ -41,6 +41,7 @@ jobs:
             opus \
             ossp-uuid \
             pcre \
+            pkgconf \
             sofia-sip \
             speex \
             speexdsp \


### PR DESCRIPTION
Tested on empty Mac Intel and Apple Silicon. Both failed due to missing pkgconf. It is required and not auto downloaded as prerequisite to other packages.

Note the name is now pkgconf on homebrew. It is the newer version of pkg-config and pkgconfig which are now aliases that point to pkgconf on homebrew.