### PR TITLE
Update macos.yml ffmpeg and libpq for FreeSwitch 1.11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,11 +35,11 @@ jobs:
             autoconf \
             automake \
             curl \
-            ffmpeg@5 \
+            ffmpeg@7 \
             gnu-sed \
             jpeg \
             ldns \
-            libpq@16 \
+            libpq@18 \
             libsndfile \
             libtool \
             lua \
@@ -60,8 +60,8 @@ jobs:
             signalwire/homebrew-signalwire/spandsp \
           && \
           brew link --force --overwrite \
-            ffmpeg@5 \
-            libpq@16
+            ffmpeg@7 \
+            libpq@18
 
       - name: Bootstrap FreeSWITCH
         run: ./bootstrap.sh -j


### PR DESCRIPTION
ffmpeg@5 changed to ffmpeg@7
Note: tested ffmpeg@8 but it causes missing ft2build.h in truetype include library.

libpq@16 changed to libpq@18